### PR TITLE
bendechrai/no redirect to cart

### DIFF
--- a/app/code/community/CoreValue/FacebookPixel/etc/config.xml
+++ b/app/code/community/CoreValue/FacebookPixel/etc/config.xml
@@ -26,14 +26,14 @@
             </updates>
         </layout>
         <events>
-            <controller_action_predispatch_checkout_cart_add><!-- fires when adding to cart -->
+            <checkout_cart_add_product_complete><!-- fires from Mage_Checkout_CartController::addAction() -->
                 <observers>
                     <corevalue_facebookpixel>
                         <class>corevalue_facebookpixel/observer</class>
                         <method>addItemToCart</method>
                     </corevalue_facebookpixel>
                 </observers>
-            </controller_action_predispatch_checkout_cart_add>
+            </checkout_cart_add_product_complete>
 
             <controller_action_predispatch_wishlist_index_add><!-- fires when adding to wishlist -->
                 <observers>

--- a/app/design/frontend/base/default/layout/corevalue_facebookpixel.xml
+++ b/app/design/frontend/base/default/layout/corevalue_facebookpixel.xml
@@ -18,6 +18,7 @@
     <catalog_product_view>
         <reference name="head">
             <block type="core/template" template="facebookpixel/view.phtml"/>
+            <block type="core/template" template="facebookpixel/addtocart.phtml"/>
         </reference>
     </catalog_product_view>
     <checkout_cart_index>
@@ -27,6 +28,7 @@
     </checkout_cart_index>
     <wishlist_index_index>
         <reference name="head">
+            <block type="core/template" template="facebookpixel/addtocart.phtml"/>
             <block type="core/template" template="facebookpixel/addtowishlist.phtml"/>
         </reference>
     </wishlist_index_index>

--- a/app/design/frontend/base/default/template/facebookpixel/addtowishlist.phtml
+++ b/app/design/frontend/base/default/template/facebookpixel/addtowishlist.phtml
@@ -13,7 +13,8 @@ $_product = Mage::getModel('core/session')->getProductToWishlist()
     <script>
             fbq('track', 'AddToWishlist', {
                 content_name: '<?php echo $_product->getName()?>',
-                content_ids: '<?php $_product->getSku()?>',
+                content_type: 'product',
+                content_ids: '<?php echo $_product->getSku()?>',
                 content_category: 'product',
                 value: '<?php echo number_format((float)$_product->getPrice(),2,'.','');?>',
                 currency: '<?php echo Mage::app()->getStore()->getCurrentCurrencyCode();?>'


### PR DESCRIPTION
Hi there! I just implemented this on a client's website. Thanks for a convenient extension :)

My client's site was configured to return to the previous page after AddToCart (not go to the cart), which meant the correct pixel event wasn't being triggered. This PR fixes that, and still works when the user is taken to the cart.

I also noticed that the AddToWishlist event didn't include the content_type, and the value of the content_ids wasn't actually being echoed, so this PR includes that fix too.

Cheers!
Ben